### PR TITLE
Add cartridge support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /data
 /target
 **/*.rs.bk
+*_boot.bin

--- a/src/gameboy/hardware/cartridge/mod.rs
+++ b/src/gameboy/hardware/cartridge/mod.rs
@@ -1,0 +1,16 @@
+pub struct Cartridge {
+    rom: Box<[u8]>,
+}
+
+impl Cartridge {
+    pub fn new(rom: Box<[u8]>) -> Self {
+        Self {
+            rom: rom,
+        }
+    }
+
+    pub fn read(&self, addr: u16) -> u8 {
+        let actual_addr = addr - 0x0100;
+        return self.rom[actual_addr as usize];
+    }
+}

--- a/src/gameboy/hardware/mod.rs
+++ b/src/gameboy/hardware/mod.rs
@@ -3,3 +3,4 @@ mod bus;
 pub mod cpu;
 pub mod interconnect;
 mod ppu;
+mod cartridge;

--- a/src/gameboy/mod.rs
+++ b/src/gameboy/mod.rs
@@ -10,10 +10,10 @@ pub struct GameBoy {
 }
 
 impl GameBoy {
-    pub fn new(bootrom: Box<[u8]>) -> Self {
+    pub fn new(bootrom: Box<[u8]>, rom: Box<[u8]>) -> Self {
         Self {
             cpu: LR35902::new(),
-            interconnect: Interconnect::new(bootrom),
+            interconnect: Interconnect::new(bootrom, rom),
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -32,7 +32,10 @@ fn main() {
     let bootrom_file_name = env::args().nth(1).unwrap();
     let bootrom = read_bin(bootrom_file_name);
 
-    let gb = GameBoy::new(bootrom);
+    let rom_file_name = env::args().nth(2).unwrap();
+    let rom = read_bin(rom_file_name);
+
+    let gb = GameBoy::new(bootrom, rom);
     // let mut emu = Emulator::new(gb);
     let mut dbg = Debugger::new(gb);
     dbg.run();


### PR DESCRIPTION
Add support to load game ROM.

Must be supplied as a parameter with bootrom:
```bash
cargo run boot.bin pokemon.rom
```

It just abstracts cartridge logic, to paginate memory when reading from `Interconnect`.